### PR TITLE
chore: scaffold monorepo with engine, api, web

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,10 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+# Node
+node_modules/
+web/node_modules/
+web/dist/
+
+# Vite
+vite.config.ts.timestamp-*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+.PHONY: install dev-api dev-web test fmt
+
+install:
+pip install -e engine[dev]
+pip install -e api[dev]
+npm --prefix web install
+echo 'Install complete'
+
+dev-api:
+UVICORN_RELOAD_DIRS=api uvicorn api.main:create_app --factory --reload
+
+dev-web:
+npm --prefix web run dev
+
+test:
+pytest engine/tests api/tests
+
+fmt:
+ruff .
+black .

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # regex-lite
+
+Minimal monorepo containing a toy regex engine, a FastAPI API, and a React UI.
+
+## Quickstart
+
+```bash
+make install
+USE_MOCK_ENGINE=1 make dev-api
+make dev-web
+```
+
+Open [http://localhost:5173](http://localhost:5173) and try the pattern `\\d+` on the text `abc 123 xyz`.

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY engine/ engine/
+COPY api/ api/
+RUN pip install --no-cache-dir -e engine -e api
+
+CMD ["uvicorn", "api.main:create_app", "--factory", "--host", "0.0.0.0", "--port", "8000"]

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,5 @@
+# API Checklist
+
+- [ ] Wire up `RealEngine` once engine is feature-complete
+- [ ] Improve error handling and validation
+- [ ] Expand test coverage for edge cases

--- a/api/api/__init__.py
+++ b/api/api/__init__.py
@@ -1,0 +1,1 @@
+"""API package for regex-lite."""

--- a/api/api/adapters.py
+++ b/api/api/adapters.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import os
+import re
+from typing import List, Optional, Tuple
+
+from regex_lite import matcher
+
+
+class EngineAdapter:
+    def match(self, pattern: str, flags: str, text: str) -> List[dict]:
+        raise NotImplementedError
+
+    def replace(
+        self, pattern: str, flags: str, text: str, repl: str
+    ) -> Tuple[str, int]:
+        raise NotImplementedError
+
+    def split(self, pattern: str, flags: str, text: str) -> List[str]:
+        raise NotImplementedError
+
+
+def _translate_flags(flag_str: str) -> int:
+    mapping = {"i": re.IGNORECASE, "m": re.MULTILINE, "s": re.DOTALL}
+    value = 0
+    for ch in flag_str:
+        value |= mapping.get(ch, 0)
+    return value
+
+
+class MockEngine(EngineAdapter):
+    def match(self, pattern: str, flags: str, text: str) -> List[dict]:
+        regex = re.compile(pattern, _translate_flags(flags))
+        matches = []
+        for m in regex.finditer(text):
+            groups: List[Optional[Tuple[int, int]]] = []
+            for i in range(1, m.re.groups + 1):
+                span = m.span(i)
+                groups.append(span if m.group(i) is not None else None)
+            matches.append({"span": m.span(), "groups": groups})
+        return matches
+
+    def replace(
+        self, pattern: str, flags: str, text: str, repl: str
+    ) -> Tuple[str, int]:
+        regex = re.compile(pattern, _translate_flags(flags))
+        result, count = regex.subn(repl, text)
+        return result, count
+
+    def split(self, pattern: str, flags: str, text: str) -> List[str]:
+        regex = re.compile(pattern, _translate_flags(flags))
+        return regex.split(text)
+
+
+class RealEngine(EngineAdapter):
+    def match(self, pattern: str, flags: str, text: str) -> List[dict]:
+        return matcher.match(pattern, text, flags)
+
+    def replace(
+        self, pattern: str, flags: str, text: str, repl: str
+    ) -> Tuple[str, int]:
+        raise NotImplementedError
+
+    def split(self, pattern: str, flags: str, text: str) -> List[str]:
+        raise NotImplementedError
+
+
+def get_engine() -> EngineAdapter:
+    use_mock = os.getenv("USE_MOCK_ENGINE", "1") != "0"
+    return MockEngine() if use_mock else RealEngine()

--- a/api/api/main.py
+++ b/api/api/main.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+
+from .adapters import get_engine
+from .schemas import (
+    MatchRequest,
+    MatchResponse,
+    ReplaceRequest,
+    ReplaceResponse,
+    SplitRequest,
+    SplitResponse,
+)
+
+
+def create_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    engine = get_engine()
+
+    @app.get("/healthz")
+    def healthz() -> dict[str, bool]:
+        return {"ok": True}
+
+    @app.post("/regex/match", response_model=MatchResponse)
+    def regex_match(req: MatchRequest) -> MatchResponse:
+        try:
+            matches = engine.match(req.pattern, req.flags, req.text)
+        except NotImplementedError as exc:
+            raise HTTPException(status_code=501, detail=str(exc))
+        return MatchResponse(matches=matches)
+
+    @app.post("/regex/replace", response_model=ReplaceResponse)
+    def regex_replace(req: ReplaceRequest) -> ReplaceResponse:
+        try:
+            output, count = engine.replace(req.pattern, req.flags, req.text, req.repl)
+        except NotImplementedError as exc:
+            raise HTTPException(status_code=501, detail=str(exc))
+        return ReplaceResponse(output=output, count=count)
+
+    @app.post("/regex/split", response_model=SplitResponse)
+    def regex_split(req: SplitRequest) -> SplitResponse:
+        try:
+            pieces = engine.split(req.pattern, req.flags, req.text)
+        except NotImplementedError as exc:
+            raise HTTPException(status_code=501, detail=str(exc))
+        return SplitResponse(pieces=pieces)
+
+    return app

--- a/api/api/schemas.py
+++ b/api/api/schemas.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import List, Optional, Tuple
+
+from pydantic import BaseModel
+
+
+class MatchRequest(BaseModel):
+    pattern: str
+    text: str
+    flags: str = ""
+
+
+class ReplaceRequest(MatchRequest):
+    repl: str
+
+
+class SplitRequest(MatchRequest):
+    pass
+
+
+class Match(BaseModel):
+    span: Tuple[int, int]
+    groups: List[Optional[Tuple[int, int]]]
+
+
+class MatchResponse(BaseModel):
+    matches: List[Match]
+
+
+class ReplaceResponse(BaseModel):
+    output: str
+    count: int
+
+
+class SplitResponse(BaseModel):
+    pieces: List[str]

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "regex-lite-api"
+version = "0.0.1"
+description = "FastAPI service for regex-lite"
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi",
+    "uvicorn[standard]",
+    "pydantic",
+    "regex-lite-engine @ file:../engine",
+]
+
+[project.optional-dependencies]
+dev = ["httpx", "pytest"]

--- a/api/tests/test_api_contract.py
+++ b/api/tests/test_api_contract.py
@@ -1,0 +1,66 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import create_app
+
+
+@pytest.fixture(params=[True, False], ids=["mock", "real"])
+def client(request, monkeypatch):
+    use_mock = request.param
+    monkeypatch.setenv("USE_MOCK_ENGINE", "1" if use_mock else "0")
+    app = create_app()
+    return TestClient(app), use_mock
+
+
+def test_health(client):
+    cli, _ = client
+    resp = cli.get("/healthz")
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+
+
+def test_match(client):
+    cli, use_mock = client
+    resp = cli.post(
+        "/regex/match",
+        json={"pattern": "\\d+", "text": "abc 123 xyz", "flags": ""},
+    )
+    if use_mock:
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["matches"][0]["span"] == [4, 7]
+    else:
+        assert resp.status_code == 501
+
+
+def test_replace(client):
+    cli, use_mock = client
+    resp = cli.post(
+        "/regex/replace",
+        json={
+            "pattern": "\\d+",
+            "text": "abc 123 xyz",
+            "flags": "",
+            "repl": "#",
+        },
+    )
+    if use_mock:
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data == {"output": "abc # xyz", "count": 1}
+    else:
+        assert resp.status_code == 501
+
+
+def test_split(client):
+    cli, use_mock = client
+    resp = cli.post(
+        "/regex/split",
+        json={"pattern": " ", "text": "a b c", "flags": ""},
+    )
+    if use_mock:
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["pieces"] == ["a", "b", "c"]
+    else:
+        assert resp.status_code == 501

--- a/engine/README.md
+++ b/engine/README.md
@@ -1,0 +1,6 @@
+# Engine Checklist
+
+- [ ] Implement full parser for regex syntax
+- [ ] Build Thompson ε-NFA compiler
+- [ ] Implement matcher using ε-closure simulation
+- [ ] Add property-based tests with Hypothesis

--- a/engine/pyproject.toml
+++ b/engine/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "regex-lite-engine"
+version = "0.0.1"
+description = "Toy regex engine"
+requires-python = ">=3.11"
+dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest", "hypothesis"]

--- a/engine/regex_lite/__init__.py
+++ b/engine/regex_lite/__init__.py
@@ -1,0 +1,5 @@
+"""regex_lite engine package."""
+
+from .lexer import Lexer, tokenize
+
+__all__ = ["Lexer", "tokenize"]

--- a/engine/regex_lite/ast.py
+++ b/engine/regex_lite/ast.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+
+class Node:
+    pass
+
+
+@dataclass
+class Literal(Node):
+    value: str
+
+
+@dataclass
+class Dot(Node):
+    pass
+
+
+@dataclass
+class Sequence(Node):
+    parts: List[Node]
+
+
+@dataclass
+class Alternation(Node):
+    left: Node
+    right: Node
+
+
+@dataclass
+class Repeat(Node):
+    expr: Node
+    op: str
+
+
+@dataclass
+class Group(Node):
+    expr: Node

--- a/engine/regex_lite/compiler.py
+++ b/engine/regex_lite/compiler.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from . import ast
+
+
+def compile(ast_tree: ast.Node) -> object:
+    """Compile AST into internal NFA representation."""
+    raise NotImplementedError("Compiler not implemented")

--- a/engine/regex_lite/lexer.py
+++ b/engine/regex_lite/lexer.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from .tokens import Token, TokenType
+
+
+class Lexer:
+    def __init__(self, pattern: str) -> None:
+        self.pattern = pattern
+
+    def tokenize(self) -> list[Token]:
+        tokens: list[Token] = []
+        i = 0
+        while i < len(self.pattern):
+            ch = self.pattern[i]
+            if ch == "\\":
+                i += 1
+                if i >= len(self.pattern):
+                    raise ValueError("dangling escape")
+                tokens.append(Token(TokenType.CHAR, self.pattern[i]))
+            elif ch == ".":
+                tokens.append(Token(TokenType.DOT))
+            elif ch == "*":
+                tokens.append(Token(TokenType.STAR))
+            elif ch == "+":
+                tokens.append(Token(TokenType.PLUS))
+            elif ch == "?":
+                tokens.append(Token(TokenType.QUESTION))
+            elif ch == "(":
+                tokens.append(Token(TokenType.LPAREN))
+            elif ch == ")":
+                tokens.append(Token(TokenType.RPAREN))
+            elif ch == "|":
+                tokens.append(Token(TokenType.PIPE))
+            else:
+                tokens.append(Token(TokenType.CHAR, ch))
+            i += 1
+        tokens.append(Token(TokenType.EOF))
+        return tokens
+
+
+def tokenize(pattern: str) -> list[Token]:
+    return Lexer(pattern).tokenize()

--- a/engine/regex_lite/matcher.py
+++ b/engine/regex_lite/matcher.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+
+def match(pattern: str, text: str, flags: str = "") -> list[tuple[int, int]]:
+    """Stub matcher that will eventually simulate the NFA."""
+    raise NotImplementedError("Matcher not implemented")

--- a/engine/regex_lite/parser.py
+++ b/engine/regex_lite/parser.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from . import ast
+
+
+def parse(pattern: str) -> ast.Node:
+    """Parse pattern into an AST."""
+    raise NotImplementedError("Parser not implemented")

--- a/engine/regex_lite/tokens.py
+++ b/engine/regex_lite/tokens.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum, auto
+
+
+class TokenType(Enum):
+    CHAR = auto()
+    DOT = auto()
+    STAR = auto()
+    PLUS = auto()
+    QUESTION = auto()
+    LPAREN = auto()
+    RPAREN = auto()
+    PIPE = auto()
+    EOF = auto()
+
+
+@dataclass
+class Token:
+    type: TokenType
+    value: str | None = None

--- a/engine/tests/test_lexer.py
+++ b/engine/tests/test_lexer.py
@@ -1,0 +1,23 @@
+from regex_lite.lexer import tokenize
+from regex_lite.tokens import TokenType
+
+
+def test_digits():
+    tokens = tokenize("123")
+    assert [t.type for t in tokens] == [
+        TokenType.CHAR,
+        TokenType.CHAR,
+        TokenType.CHAR,
+        TokenType.EOF,
+    ]
+
+
+def test_dot():
+    tokens = tokenize(".")
+    assert [t.type for t in tokens] == [TokenType.DOT, TokenType.EOF]
+
+
+def test_escape_metachar():
+    tokens = tokenize("\\.")
+    assert tokens[0].type == TokenType.CHAR
+    assert tokens[0].value == "."

--- a/engine/tests/test_matcher_smoke.py
+++ b/engine/tests/test_matcher_smoke.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.mark.skip(reason="matcher not implemented")
+def test_matcher_smoke():
+    pass

--- a/engine/tests/test_parser.py
+++ b/engine/tests/test_parser.py
@@ -1,0 +1,13 @@
+from regex_lite import ast, parser
+
+
+def test_alternation_precedence():
+    tree = parser.parse("a|bc")
+    assert isinstance(tree, ast.Alternation)
+    assert isinstance(tree.right, ast.Sequence)
+
+
+def test_grouping():
+    tree = parser.parse("(ab)c")
+    assert isinstance(tree, ast.Sequence)
+    assert isinstance(tree.parts[0], ast.Group)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,13 @@
-[project]
-name = "regex-lite"
-version = "0.1.0"
-description = "Add your description here"
-requires-python = ">=3.9"
-dependencies = []
+[tool.black]
+line-length = 88
+target-version = ["py311"]
+
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+extend-select = ["I"]
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+addopts = "-ra -q"
+testpaths = ["engine/tests", "api/tests"]

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,5 @@
+# Web Checklist
+
+- [ ] Style the interface and add match highlighting
+- [ ] Validate user input and surface errors
+- [ ] Add basic tests for components and API client

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>regex-lite</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "regex-lite-web",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "axios": "^1.6.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+import { match } from './api';
+
+export default function App() {
+  const [pattern, setPattern] = useState('');
+  const [flags, setFlags] = useState('');
+  const [text, setText] = useState('');
+  const [result, setResult] = useState<any>(null);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const data = await match(pattern, flags, text);
+    setResult(data);
+  };
+
+  return (
+    <div style={{ padding: '1rem', fontFamily: 'sans-serif' }}>
+      <h1>regex-lite</h1>
+      <form onSubmit={onSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', maxWidth: '400px' }}>
+        <label>
+          Pattern
+          <input value={pattern} onChange={e => setPattern(e.target.value)} />
+        </label>
+        <label>
+          Flags
+          <input value={flags} onChange={e => setFlags(e.target.value)} />
+        </label>
+        <label>
+          Text
+          <textarea value={text} onChange={e => setText(e.target.value)} rows={4} />
+        </label>
+        <button type="submit">Match</button>
+      </form>
+      {result && (
+        <div>
+          <h2>Result</h2>
+          <pre>{JSON.stringify(result, null, 2)}</pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+const API_BASE = 'http://localhost:8000';
+
+export async function match(pattern: string, flags: string, text: string) {
+  const res = await axios.post(`${API_BASE}/regex/match`, { pattern, flags, text });
+  return res.data;
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": "./src"
+  },
+  "include": ["src"]
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+  },
+});


### PR DESCRIPTION
## Summary
- set up toy regex engine package with lexer and AST stubs
- add FastAPI API with mock/real engine adapters and regex endpoints
- scaffold React + Vite web UI for exercising the API
- add per-component checklists for API, engine, and web work items

## Testing
- `ruff check .`
- `black .`
- `pip install -e engine[dev] -e api[dev]` *(fails: Could not find a version that satisfies the requirement hatchling)*
- `PYTHONPATH=engine pytest engine/tests api/tests -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_689e4e411434832e8bd61c6f9eb9cbe8