### PR TITLE
feat: implement Pratt parser

### DIFF
--- a/engine/README.md
+++ b/engine/README.md
@@ -2,13 +2,13 @@
 
 * [ ] **Define subset & flags** (readme spec): literals, `. [] ^ $ () | * + ? {m,n}`, escapes, ranges; flags `i/m/s/g`;
   anchors `^/$`.
-* [ ] **Tokens** (`tokens.py`): metachars, escapes (inside/outside `[]`), `\t \n \r \xHH`, shorthands as
+* [x] **Tokens** (`tokens.py`): metachars, escapes (inside/outside `[]`), `\t \n \r \xHH`, shorthands as
   `Shorthand('d'|'w'|'s'|…)`.
-* [ ] **Lexer** (`lexer.py`): one-pass with positions; class rules (negation if first `^`, ranges with `-`, literal `-`
+* [x] **Lexer** (`lexer.py`): one-pass with positions; class rules (negation if first `^`, ranges with `-`, literal `-`
   and `]` handling).
-* [ ] **AST dataclasses** (`ast.py`):
+* [x] **AST dataclasses** (`ast.py`):
   `Literal, Dot, AnchorStart, AnchorEnd, CharClass, Range, Group(index), Concat, Alt, Repeat, Shorthand`.
-* [ ] **Parser** (`parser.py`): Pratt or shunting-yard; implicit concatenation; group numbering; quantifier validation (
+* [x] **Parser** (`parser.py`): Pratt or shunting-yard; implicit concatenation; group numbering; quantifier validation (
   `{m}`, `{m,}`, `{m,n}` with `m≤n`); precise error types.
 * [ ] **Thompson compiler** (`compiler.py`): per-node builders
 
@@ -28,8 +28,8 @@
 
 * [ ] **Unit (engine)**
 
-    * [ ] Lexer: escapes, ranges, `[]` edge cases
-    * [ ] Parser: precedence (`a|bc*`), grouping, quantifiers, anchors
+    * [x] Lexer: escapes, ranges, `[]` edge cases
+    * [x] Parser: precedence (`a|bc*`), grouping, quantifiers, anchors
     * [ ] Compiler/Matcher: literals/dot/classes/alt/concat/repeat, flags, anchors, captures
 * [ ] **Property tests** (Hypothesis): random small patterns/inputs vs Python `re` where semantics overlap
 * [ ] **Golden tests**: curated patterns → expected spans/captures; replace/split outputs

--- a/engine/regex_lite/parser.py
+++ b/engine/regex_lite/parser.py
@@ -228,13 +228,31 @@ class Parser:
         if t.type == TokenType.CARET:
             self.advance()
             return ast.Literal("^")
-        # Any other token inside class is treated as literal of its value
+        # Any other token inside a class is treated as its literal character.
+        mapping = {
+            TokenType.DOT: ".",
+            TokenType.STAR: "*",
+            TokenType.PLUS: "+",
+            TokenType.QUESTION: "?",
+            TokenType.LBRACE: "{",
+            TokenType.RBRACE: "}",
+            TokenType.LPAREN: "(",
+            TokenType.RPAREN: ")",
+            TokenType.LBRACKET: "[",
+            TokenType.RBRACKET: "]",
+            TokenType.PIPE: "|",
+            TokenType.COMMA: ",",
+        }
         self.advance()
-        if t.value is None:
+        if t.value is not None:
+            ch = t.value
+        elif t.type in mapping:
+            ch = mapping[t.type]
+        else:
             raise RegexSyntaxError(
                 "unexpected token with no value in character class", t.pos
             )
-        return ast.Literal(t.value)
+        return ast.Literal(ch)
 
 
 def parse(pattern: str) -> ast.Expr:

--- a/engine/tests/test_lexer.py
+++ b/engine/tests/test_lexer.py
@@ -1,3 +1,4 @@
+import pytest
 from regex_lite.lexer import tokenize
 from regex_lite.tokens import TokenType
 
@@ -56,3 +57,29 @@ def test_hex_and_controls():
     tokens = tokenize("\\t\\n")
     assert types(tokens) == [TokenType.CHAR, TokenType.CHAR, TokenType.EOF]
     assert tokens[0].value == "\t" and tokens[1].value == "\n"
+
+
+def test_char_class_metacharacters_literal():
+    tokens = tokenize("[.*+?(){}|]")
+    assert types(tokens) == [
+        TokenType.LBRACKET,
+        TokenType.CHAR,
+        TokenType.CHAR,
+        TokenType.CHAR,
+        TokenType.CHAR,
+        TokenType.CHAR,
+        TokenType.CHAR,
+        TokenType.CHAR,
+        TokenType.CHAR,
+        TokenType.CHAR,
+        TokenType.RBRACKET,
+        TokenType.EOF,
+    ]
+    assert [t.value for t in tokens[1:-2]] == list(".*+?(){}|")
+
+
+def test_invalid_escape_sequences():
+    with pytest.raises(ValueError):
+        tokenize("\\q")
+    with pytest.raises(ValueError):
+        tokenize("\\x1")

--- a/engine/tests/test_parser.py
+++ b/engine/tests/test_parser.py
@@ -50,6 +50,17 @@ def test_grouping():
     assert isinstance(d, ast.Literal) and d.char == "d"
 
 
+def test_nested_group_numbering():
+    tree = parser.parse("(a(b)c)")
+    assert isinstance(tree, ast.Group) and tree.index == 1
+    assert isinstance(tree.expr, ast.Concat)
+    a, inner, c = tree.expr.parts
+    assert isinstance(a, ast.Literal) and a.char == "a"
+    assert isinstance(inner, ast.Group) and inner.index == 2
+    assert isinstance(inner.expr, ast.Literal) and inner.expr.char == "b"
+    assert isinstance(c, ast.Literal) and c.char == "c"
+
+
 def test_quantifiers_and_literals():
     tree = parser.parse("a{2,3}b+c?")
     assert isinstance(tree, ast.Concat)
@@ -95,6 +106,19 @@ def test_char_class_and_anchors():
     assert isinstance(tree.parts[1], ast.Repeat)
     assert isinstance(tree.parts[1].expr, ast.Shorthand)
     assert isinstance(tree.parts[-1], ast.AnchorEnd)
+
+
+def test_char_class_punctuation_literals():
+    tree = parser.parse("[.*+?(){}|]")
+    assert isinstance(tree, ast.CharClass)
+    assert [item.char for item in tree.items] == list(".*+?(){}|")
+
+
+def test_char_class_errors():
+    with pytest.raises(parser.RegexSyntaxError):
+        parser.parse("[z-a]")
+    with pytest.raises(parser.RegexSyntaxError):
+        parser.parse("[abc")
 
 
 def test_errors():


### PR DESCRIPTION
## Summary
- handle literal punctuation tokens inside character classes
- mark tokens, lexer, AST, and parser as completed in engine checklist
- expand lexer and parser unit tests for metacharacter classes, invalid escapes, nested groups, and char-class errors

## Testing
- `uv run black engine/tests/test_lexer.py engine/tests/test_parser.py`
- `uv run ruff check engine/tests/test_lexer.py engine/tests/test_parser.py --fix`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd23dff13c832eb7002e09f2727aae