### PR TITLE
refactor(engine): remove g flag spec and deduplicate `match_spans`

### DIFF
--- a/engine/README.md
+++ b/engine/README.md
@@ -1,6 +1,6 @@
 # Engine Checklist
 
-* [ ] **Define subset & flags** (readme spec): literals, `. [] ^ $ () | * + ? {m,n}`, escapes, ranges; flags `i/m/s/g`;
+* [ ] **Define subset & flags** (readme spec): literals, `. [] ^ $ () | * + ? {m,n}`, escapes, ranges; flags `i/m/s`;
   anchors `^/$`.
 * [x] **Tokens** (`tokens.py`): metachars, escapes (inside/outside `[]`), `\t \n \r \xHH`, shorthands as
   `Shorthand('d'|'w'|'s'|…)`.
@@ -19,7 +19,7 @@
 * [ ] **Matcher** (`matcher.py`): ε-closure NFA simulation
 
     * [ ] Case-folding for `i`, line vs. string semantics for `m`, dotall for `s`
-    * [ ] First vs. global (`g`) search; leftmost-longest greedy behavior
+    * [ ] Leftmost-longest greedy behavior
     * [ ] Capture spans for numbered groups
 * [ ] **Replace / Split semantics**: `$1…` back-refs; count; split with `limit` (optional)
 * [ ] **Performance sanity**: typical pattern compiles <150ms; match small texts <5–10ms; simple micro-bench script


### PR DESCRIPTION
## Summary
- update the engine documentation to drop references to the removed `g` flag
- simplify `match_spans` to reuse `match` and clarify its documentation comment

## Testing
- uv run pytest engine/tests/test_matcher_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68d6f50286d0832e88b61be3093fc973

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing feature changes.

- Documentation
  - Updated Engine Checklist to reflect supported flags (i/m/s) and clarified matching behavior as leftmost-longest greedy, removing references to global search.

- Refactor
  - Simplified span-matching to delegate to the primary matcher while preserving the public interface and results, improving consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->