### PR TITLE
refactor(engine): convert compiler to OOP architecture with NFA class

### DIFF
--- a/engine/regex_lite/compiler.py
+++ b/engine/regex_lite/compiler.py
@@ -30,327 +30,312 @@ class State:
     exit_groups: List[int] = field(default_factory=list)
 
 
-@dataclass
 class NFA:
-    states: List[State]
-    start: int
-    accepts: Set[int]
+    """NFA (Non-deterministic Finite Automaton) compiled from regex AST."""
+
+    def __init__(self, tree: ast.Node):
+        self.states: List[State] = []
+        self.start, _ = self._build(tree)
+
+    # === Low-level state operations ===
+
+    def _new_state(self, accept: bool = False) -> int:
+        self.states.append(State(accept=accept))
+        return len(self.states) - 1
+
+    def _add_eps(self, u: int, v: int) -> None:
+        self.states[u].eps.append(v)
+
+    def _add_edge(self, u: int, kind: str, data: Any, v: int) -> None:
+        self.states[u].edges.append(Edge(kind, data, v))
+
+    def _mark_accept(self, i: int, val: bool) -> None:
+        self.states[i].accept = val
+
+    # === Fragment construction ===
+
+    def _frag_literal(self, ch: str) -> Tuple[int, int]:
+        s = self._new_state()
+        a = self._new_state(True)
+        self._add_edge(s, "char", ch, a)
+        return s, a
+
+    def _frag_dot(self) -> Tuple[int, int]:
+        s = self._new_state()
+        a = self._new_state(True)
+        self._add_edge(s, "dot", None, a)
+        return s, a
+
+    def _frag_shorthand(self, kind: str) -> Tuple[int, int]:
+        # kind in {'d','w','s'} — interpreted in matcher
+        s = self._new_state()
+        a = self._new_state(True)
+        self._add_edge(s, "pred", kind, a)
+        return s, a
+
+    def _frag_charclass(self, negated: bool, items: Iterable) -> Tuple[int, int]:
+        from . import ast as A
+
+        lits: Set[str] = set()
+        ranges: List[Tuple[str, str]] = []
+        for it in items:
+            if isinstance(it, A.Range):
+                ranges.append((str(it.start), str(it.end)))
+            elif isinstance(it, A.Literal):
+                lits.add(str(it.char))
+            else:
+                # Fallback: treat as a character
+                lits.add(str(it))
+        s = self._new_state()
+        a = self._new_state(True)
+        self._add_edge(s, "class", (negated, frozenset(lits), tuple(ranges)), a)
+        return s, a
+
+    def _frag_concat(self, frags: List[Tuple[int, int]]) -> Tuple[int, int]:
+        if not frags:
+            # Empty string
+            s = self._new_state()
+            a = self._new_state(True)
+            self._add_eps(s, a)
+            return s, a
+        s0, a0 = frags[0]
+        for s1, a1 in frags[1:]:
+            self._mark_accept(a0, False)
+            self._add_eps(a0, s1)
+            a0 = a1
+        self._mark_accept(a0, True)
+        return s0, a0
+
+    def _frag_alt(
+        self, left: Tuple[int, int], right: Tuple[int, int]
+    ) -> Tuple[int, int]:
+        s = self._new_state()
+        a = self._new_state(True)
+        ls, la = left
+        rs, ra = right
+        self._mark_accept(la, False)
+        self._mark_accept(ra, False)
+        self._add_eps(s, ls)
+        self._add_eps(s, rs)
+        self._add_eps(la, a)
+        self._add_eps(ra, a)
+        return s, a
+
+    def _clone_fragment(self, base: Tuple[int, int]) -> Tuple[int, int]:
+        """
+        Creates a fresh copy of a fragment by cloning all states reachable from base.
+        Returns a new (start, accept) pair with completely new state indices.
+        """
+        start_old, accept_old = base
+
+        # Map old state indices to new state indices
+        state_map = {}
+
+        # Collect all reachable states from the fragment via DFS
+        reachable = set()
+        stack = [start_old]
+        while stack:
+            state_idx = stack.pop()
+            if state_idx in reachable:
+                continue
+            reachable.add(state_idx)
+
+            state = self.states[state_idx]
+            # Add epsilon transitions
+            for eps_target in state.eps:
+                if eps_target not in reachable:
+                    stack.append(eps_target)
+            # Add edge transitions
+            for edge in state.edges:
+                if edge.to not in reachable:
+                    stack.append(edge.to)
+
+        # Create new states for all reachable states
+        for old_idx in reachable:
+            old_state = self.states[old_idx]
+            new_idx = self._new_state(old_state.accept)
+            state_map[old_idx] = new_idx
+
+            # Copy other state properties
+            new_state = self.states[new_idx]
+            new_state.require_bol = old_state.require_bol
+            new_state.require_eol = old_state.require_eol
+            new_state.enter_groups = old_state.enter_groups.copy()
+            new_state.exit_groups = old_state.exit_groups.copy()
+
+        # Clone all edges and epsilon transitions
+        for old_idx in reachable:
+            old_state = self.states[old_idx]
+            new_idx = state_map[old_idx]
+            new_state = self.states[new_idx]
+
+            # Clone epsilon transitions
+            for eps_target in old_state.eps:
+                if eps_target in state_map:
+                    new_state.eps.append(state_map[eps_target])
+
+            # Clone edges
+            for edge in old_state.edges:
+                if edge.to in state_map:
+                    new_state.edges.append(
+                        Edge(edge.kind, edge.data, state_map[edge.to])
+                    )
+
+        return state_map[start_old], state_map[accept_old]
+
+    def _repeat_range(
+        self, base: Tuple[int, int], min_: int, max_: Optional[int]
+    ) -> Tuple[int, int]:
+        """
+        Thompson expansion: repeat at least `min_` times + optionally (max_-min_) times;
+        max_=None means no upper limit.
+        """
+        # Start with an empty entry state
+        s_all = self._new_state()
+        cur_a = s_all  # initially empty
+        # Required min_ repetitions: concatenate sequentially
+        for _ in range(min_):
+            s, a = self._clone_fragment(base)
+            self._mark_accept(a, False)
+            self._add_eps(cur_a, s)
+            cur_a = a
+
+        if min_ == 0:
+            # Allow empty: jump from start directly to current a
+            cur_a = s_all
+
+        # Finite upper bound: add (max_-min_) optional repetitions
+        if max_ is not None:
+            reps = max(0, max_ - min_)
+            for _ in range(reps):
+                s, a = self._clone_fragment(base)
+                self._mark_accept(a, False)
+
+                # Create new accept for this optional iteration
+                new_a = self._new_state()
+
+                # Option: skip to new_a
+                self._add_eps(cur_a, new_a)
+                # Or: take base once
+                self._add_eps(cur_a, s)
+                self._add_eps(a, new_a)
+
+                cur_a = new_a
+
+            # End
+            self._mark_accept(cur_a, True)
+            return s_all, cur_a
+
+        # No upper bound: add loop at the tail
+        s, a = self._clone_fragment(base)
+        self._mark_accept(a, False)
+
+        loop_state = self._new_state()
+
+        # From current position to loop entry
+        self._add_eps(cur_a, loop_state)
+
+        # From loop: either exit (will mark true later) or take base once more
+        self._add_eps(loop_state, s)
+        self._add_eps(a, loop_state)
+
+        self._mark_accept(loop_state, True)
+        return s_all, loop_state
+
+    # === AST traversal ===
+
+    def _build(self, node: ast.Node) -> Tuple[int, int]:
+        # Literal
+        if isinstance(node, ast.Literal):
+            return self._frag_literal(node.char)
+
+        # Dot
+        if isinstance(node, ast.Dot):
+            return self._frag_dot()
+
+        # Shorthands: \d \w \s
+        if isinstance(node, ast.Shorthand):
+            return self._frag_shorthand(node.kind)
+
+        # Character class
+        if isinstance(node, ast.CharClass):
+            return self._frag_charclass(node.negated, node.items)
+
+        # Concatenation
+        if isinstance(node, ast.Concat):
+            parts = [self._build(p) for p in node.parts]
+            return self._frag_concat(parts)
+
+        # Alternation (multi-branch Alt.options)
+        if isinstance(node, ast.Alt):
+            assert node.options, "Alt.options should be non-empty"
+            fr = self._build(node.options[0])
+            for opt in node.options[1:]:
+                fr = self._frag_alt(fr, self._build(opt))
+            return fr
+
+        # Quantifiers: node.kind is '*', '+', '?', or like '{m}', '{m,}', '{m,n}'
+        if isinstance(node, ast.Repeat):
+            inner = self._build(node.expr)
+
+            k = node.kind
+            if k == "*":
+                return self._repeat_range(inner, 0, None)
+            if k == "+":
+                return self._repeat_range(inner, 1, None)
+            if k == "?":
+                return self._repeat_range(inner, 0, 1)
+
+            # Template with m/n fields
+            if k in ("{m}", "{m,}", "{m,n}"):
+                m = node.m if node.m is not None else 0
+                n = node.n  # None means no upper bound
+                return self._repeat_range(inner, m, n)
+
+            # Fallback: parse literal "{2,3}" kind string
+            if k.startswith("{") and k.endswith("}"):
+                body = k[1:-1]
+                if "," not in body:
+                    m = int(body)
+                    return self._repeat_range(inner, m, m)
+                left, right = body.split(",", 1)
+                m = int(left) if left.strip() else 0
+                n = None if right.strip() == "" else int(right)
+                return self._repeat_range(inner, m, n)
+
+            raise ValueError(f"unknown repeat kind: {k}")
+
+        # Group
+        if isinstance(node, ast.Group):
+            s, a = self._build(node.expr)
+            self.states[s].enter_groups.append(node.index)
+            self.states[a].exit_groups.append(node.index)
+            return s, a
+
+        # Anchors
+        if isinstance(node, ast.AnchorStart):
+            s = self._new_state()
+            a = self._new_state(True)
+            self.states[s].require_bol = True
+            self._add_eps(s, a)
+            return s, a
+
+        if isinstance(node, ast.AnchorEnd):
+            s = self._new_state()
+            a = self._new_state(True)
+            self.states[s].require_eol = True
+            self._add_eps(s, a)
+            return s, a
+
+        # Allow empty (if Empty node exists)
+        if hasattr(ast, "Empty") and isinstance(node, ast.Empty):
+            s = self._new_state()
+            a = self._new_state(True)
+            self._add_eps(s, a)
+            return s, a
+
+        raise NotImplementedError(f"compile: unsupported node {type(node).__name__}")
 
 
 def compile(tree: ast.Node) -> NFA:
-    states: List[State] = []
-    start, _ = _build(tree, states)
-    accepts = {i for i, st in enumerate(states) if st.accept}
-    return NFA(states=states, start=start, accepts=accepts)
-
-
-def _new_state(states: List[State], accept: bool = False) -> int:
-    states.append(State(accept=accept))
-    return len(states) - 1
-
-
-def _add_eps(states: List[State], u: int, v: int) -> None:
-    states[u].eps.append(v)
-
-
-def _add_edge(states: List[State], u: int, kind: str, data: Any, v: int) -> None:
-    states[u].edges.append(Edge(kind, data, v))
-
-
-def _mark_accept(states: List[State], i: int, val: bool) -> None:
-    states[i].accept = val
-
-
-# ---------- Fragment construction: return (start, accept) ----------
-
-
-def _frag_literal(states: List[State], ch: str) -> Tuple[int, int]:
-    s = _new_state(states)
-    a = _new_state(states, True)
-    _add_edge(states, s, "char", ch, a)
-    return s, a
-
-
-def _frag_dot(states: List[State]) -> Tuple[int, int]:
-    s = _new_state(states)
-    a = _new_state(states, True)
-    _add_edge(states, s, "dot", None, a)
-    return s, a
-
-
-def _frag_shorthand(states: List[State], kind: str) -> Tuple[int, int]:
-    # kind in {'d','w','s'} — interpreted in matcher
-    s = _new_state(states)
-    a = _new_state(states, True)
-    _add_edge(states, s, "pred", kind, a)
-    return s, a
-
-
-def _frag_charclass(
-    states: List[State], negated: bool, items: Iterable
-) -> Tuple[int, int]:
-    from . import ast as A
-
-    lits: Set[str] = set()
-    ranges: List[Tuple[str, str]] = []
-    for it in items:
-        if isinstance(it, A.Range):
-            ranges.append((str(it.start), str(it.end)))
-        elif isinstance(it, A.Literal):
-            lits.add(str(it.char))
-        else:
-            # Fallback: treat as a character
-            lits.add(str(it))
-    s = _new_state(states)
-    a = _new_state(states, True)
-    _add_edge(states, s, "class", (negated, frozenset(lits), tuple(ranges)), a)
-    return s, a
-
-
-def _frag_concat(states: List[State], frags: List[Tuple[int, int]]) -> Tuple[int, int]:
-    if not frags:
-        # Empty string
-        s = _new_state(states)
-        a = _new_state(states, True)
-        _add_eps(states, s, a)
-        return s, a
-    s0, a0 = frags[0]
-    for s1, a1 in frags[1:]:
-        _mark_accept(states, a0, False)
-        _add_eps(states, a0, s1)
-        a0 = a1
-    _mark_accept(states, a0, True)
-    return s0, a0
-
-
-def _frag_alt(
-    states: List[State], left: Tuple[int, int], right: Tuple[int, int]
-) -> Tuple[int, int]:
-    s = _new_state(states)
-    a = _new_state(states, True)
-    ls, la = left
-    rs, ra = right
-    _mark_accept(states, la, False)
-    _mark_accept(states, ra, False)
-    _add_eps(states, s, ls)
-    _add_eps(states, s, rs)
-    _add_eps(states, la, a)
-    _add_eps(states, ra, a)
-    return s, a
-
-
-def _clone_fragment(states: List[State], base: Tuple[int, int]) -> Tuple[int, int]:
-    """
-    Creates a fresh copy of a fragment by cloning all states reachable from base.
-    Returns a new (start, accept) pair with completely new state indices.
-    """
-    start_old, accept_old = base
-
-    # Map old state indices to new state indices
-    state_map = {}
-
-    # Collect all reachable states from the fragment via DFS
-    reachable = set()
-    stack = [start_old]
-    while stack:
-        state_idx = stack.pop()
-        if state_idx in reachable:
-            continue
-        reachable.add(state_idx)
-
-        state = states[state_idx]
-        # Add epsilon transitions
-        for eps_target in state.eps:
-            if eps_target not in reachable:
-                stack.append(eps_target)
-        # Add edge transitions
-        for edge in state.edges:
-            if edge.to not in reachable:
-                stack.append(edge.to)
-
-    # Create new states for all reachable states
-    for old_idx in reachable:
-        old_state = states[old_idx]
-        new_idx = _new_state(states, old_state.accept)
-        state_map[old_idx] = new_idx
-
-        # Copy other state properties
-        new_state = states[new_idx]
-        new_state.require_bol = old_state.require_bol
-        new_state.require_eol = old_state.require_eol
-        new_state.enter_groups = old_state.enter_groups.copy()
-        new_state.exit_groups = old_state.exit_groups.copy()
-
-    # Clone all edges and epsilon transitions
-    for old_idx in reachable:
-        old_state = states[old_idx]
-        new_idx = state_map[old_idx]
-        new_state = states[new_idx]
-
-        # Clone epsilon transitions
-        for eps_target in old_state.eps:
-            if eps_target in state_map:
-                new_state.eps.append(state_map[eps_target])
-
-        # Clone edges
-        for edge in old_state.edges:
-            if edge.to in state_map:
-                new_state.edges.append(Edge(edge.kind, edge.data, state_map[edge.to]))
-
-    return state_map[start_old], state_map[accept_old]
-
-
-def _repeat_range(
-    states: List[State], base: Tuple[int, int], min_: int, max_: Optional[int]
-) -> Tuple[int, int]:
-    """
-    Thompson expansion: repeat at least `min_` times + optionally (max_-min_) times;
-    max_=None means no upper limit.
-    """
-    # Start with an empty entry state
-    s_all = _new_state(states)
-    cur_a = s_all  # initially empty
-    # Required min_ repetitions: concatenate sequentially
-    for _ in range(min_):
-        s, a = _clone_fragment(states, base)
-        _mark_accept(states, a, False)
-        _add_eps(states, cur_a, s)
-        cur_a = a
-
-    if min_ == 0:
-        # Allow empty: jump from start directly to current a
-        cur_a = s_all
-
-    # Finite upper bound: add (max_-min_) optional repetitions
-    if max_ is not None:
-        reps = max(0, max_ - min_)
-        for _ in range(reps):
-            s, a = _clone_fragment(states, base)
-            _mark_accept(states, a, False)
-
-            # Create new accept for this optional iteration
-            new_a = _new_state(states)
-
-            # Option: skip to new_a
-            _add_eps(states, cur_a, new_a)
-            # Or: take base once
-            _add_eps(states, cur_a, s)
-            _add_eps(states, a, new_a)
-
-            cur_a = new_a
-
-        # End
-        _mark_accept(states, cur_a, True)
-        return s_all, cur_a
-
-    # No upper bound: add loop at the tail
-    s, a = _clone_fragment(states, base)
-    _mark_accept(states, a, False)
-
-    loop_state = _new_state(states)
-
-    # From current position to loop entry
-    _add_eps(states, cur_a, loop_state)
-
-    # From loop: either exit (will mark true later) or take base once more
-    _add_eps(states, loop_state, s)
-    _add_eps(states, a, loop_state)
-
-    _mark_accept(states, loop_state, True)
-    return s_all, loop_state
-
-
-# ---------- AST traversal ----------
-
-
-def _build(node: ast.Node, states: List[State]) -> Tuple[int, int]:
-    # Literal
-    if isinstance(node, ast.Literal):
-        return _frag_literal(states, node.char)
-
-    # Dot
-    if isinstance(node, ast.Dot):
-        return _frag_dot(states)
-
-    # Shorthands: \d \w \s
-    if isinstance(node, ast.Shorthand):
-        return _frag_shorthand(states, node.kind)
-
-    # Character class
-    if isinstance(node, ast.CharClass):
-        return _frag_charclass(states, node.negated, node.items)
-
-    # Concatenation
-    if isinstance(node, ast.Concat):
-        parts = [_build(p, states) for p in node.parts]
-        return _frag_concat(states, parts)
-
-    # Alternation (multi-branch Alt.options)
-    if isinstance(node, ast.Alt):
-        assert node.options, "Alt.options should be non-empty"
-        fr = _build(node.options[0], states)
-        for opt in node.options[1:]:
-            fr = _frag_alt(states, fr, _build(opt, states))
-        return fr
-
-    # Quantifiers: node.kind is '*', '+', '?', or like '{m}', '{m,}', '{m,n}'
-    if isinstance(node, ast.Repeat):
-        inner = _build(node.expr, states)
-
-        k = node.kind
-        if k == "*":
-            return _repeat_range(states, inner, 0, None)
-        if k == "+":
-            return _repeat_range(states, inner, 1, None)
-        if k == "?":
-            return _repeat_range(states, inner, 0, 1)
-
-        # Template with m/n fields
-        if k in ("{m}", "{m,}", "{m,n}"):
-            m = node.m if node.m is not None else 0
-            n = node.n  # None means no upper bound
-            return _repeat_range(states, inner, m, n)
-
-        # Fallback: parse literal "{2,3}" kind string
-        if k.startswith("{") and k.endswith("}"):
-            body = k[1:-1]
-            if "," not in body:
-                m = int(body)
-                return _repeat_range(states, inner, m, m)
-            left, right = body.split(",", 1)
-            m = int(left) if left.strip() else 0
-            n = None if right.strip() == "" else int(right)
-            return _repeat_range(states, inner, m, n)
-
-        raise ValueError(f"unknown repeat kind: {k}")
-
-    # Group
-    if isinstance(node, ast.Group):
-        s, a = _build(node.expr, states)
-        states[s].enter_groups.append(node.index)
-        states[a].exit_groups.append(node.index)
-        return s, a
-
-    # Anchors
-    if isinstance(node, ast.AnchorStart):
-        s = _new_state(states)
-        a = _new_state(states, True)
-        states[s].require_bol = True
-        _add_eps(states, s, a)
-        return s, a
-
-    if isinstance(node, ast.AnchorEnd):
-        s = _new_state(states)
-        a = _new_state(states, True)
-        states[s].require_eol = True
-        _add_eps(states, s, a)
-        return s, a
-
-    # Allow empty (if Empty node exists)
-    if hasattr(ast, "Empty") and isinstance(node, ast.Empty):
-        s = _new_state(states)
-        a = _new_state(states, True)
-        _add_eps(states, s, a)
-        return s, a
-
-    raise NotImplementedError(f"compile: unsupported node {type(node).__name__}")
+    return NFA(tree)


### PR DESCRIPTION
Major refactoring to eliminate parameter threading and improve maintainability:

- Remove unused `accepts` field from NFA (derived data, never used)
- Convert NFA from dataclass to regular class with constructor-based building
- Move all helper functions to NFA instance methods (eliminate `states` parameter from 20+ signatures)
- Convert recursive `_build` to instance method using `self.states`
- Simplify `compile()` to thin wrapper: `return NFA(tree)`

Benefits: Clean OOP design, no parameter threading, easier testing, same performance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked the regex compiler to a class-based, encapsulated implementation, consolidating construction and traversal logic for improved maintainability.

* **New Features**
  * None.

* **Bug Fixes**
  * None.

* **Impact**
  * No user-facing changes; existing regex behavior and public API remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->