### PR TITLE
Align playground types with API helper

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,6 @@
     "format:check": "prettier --check src/**/*.{ts,tsx,js,jsx,json,css,md}"
   },
   "dependencies": {
-    "axios": "^1.6.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,12 +1,66 @@
-import axios from "axios";
+export type Span = [number, number];
 
-const API_BASE = "http://localhost:8000";
+export interface Match {
+  span: Span;
+  groups: (Span | null)[];
+}
 
-export async function match(pattern: string, flags: string, text: string) {
-    const res = await axios.post(`${API_BASE}/regex/match`, {
-        pattern,
-        flags,
-        text,
+export interface MatchResponse {
+  matches: Match[];
+}
+
+export interface MatchRequest {
+  pattern: string;
+  flags: string;
+  text: string;
+}
+
+const DEFAULT_API_BASE = "http://localhost:8000";
+
+function resolveApiBase(): string {
+  const configuredBase = import.meta.env.VITE_API_BASE_URL?.trim();
+  if (configuredBase && configuredBase.length > 0) {
+    return configuredBase.replace(/\/$/, "");
+  }
+
+  return DEFAULT_API_BASE;
+}
+
+async function parseJsonSafely<T>(response: Response): Promise<T | null> {
+  try {
+    return (await response.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
+export async function match(request: MatchRequest): Promise<MatchResponse> {
+  try {
+    const response = await fetch(`${resolveApiBase()}/regex/match`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(request),
     });
-    return res.data;
+
+    if (!response.ok) {
+      const payload = await parseJsonSafely<{ detail?: string }>(response);
+      const message = payload?.detail ?? `Request failed with status ${response.status}`;
+      throw new Error(message);
+    }
+
+    const payload = await parseJsonSafely<MatchResponse>(response);
+    if (!payload) {
+      throw new Error("The server response could not be parsed as JSON.");
+    }
+
+    return {
+      matches: payload.matches ?? [],
+    };
+  } catch (error) {
+    if (error instanceof Error) {
+      throw error;
+    }
+
+    throw new Error("Unexpected error while communicating with the API.");
+  }
 }

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL?: string;
+  readonly VITE_USE_MOCK?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- update the API client to expose typed request/response helpers without mock URL rewriting
- adjust the playground component to consume the typed helper, narrow error handling, and reset matches safely
- trim the stylesheet back to its original structure after removing the extra UI states

## Testing
- bun run type-check

------
https://chatgpt.com/codex/tasks/task_e_68dc472cb7d0832ebdfe2ea494b3a04a